### PR TITLE
fix: 同步扫描被新一轮取代时立即中止

### DIFF
--- a/src/lib/sync/operator.ts
+++ b/src/lib/sync/operator.ts
@@ -750,6 +750,13 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
             plugin.syncState.activeSyncContext = null;
             return;
           }
+          // 本轮扫描已被新一轮同步取代（如手机切后台重连），立即退出，避免两轮扫描并发重复哈希
+          // This scan has been superseded by a newer sync (e.g. mobile background reconnect);
+          // bail out immediately so two scans never run concurrently
+          if (plugin.syncState.activeSyncContext !== context) {
+            dump(`[SyncContext] Scan (context=${context}) superseded, aborting vault scan.`);
+            return;
+          }
           const pct = Math.floor((processedCount / totalToProcess) * 100);
           plugin.progressTracker.recordHashProgress(pct);
           if (processedCount % 100 === 0) {
@@ -981,6 +988,12 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
         await sleep(0);
         if (isPluginUnloading) {
           plugin.syncState.activeSyncContext = null; // 插件卸载中，清空上下文 / Plugin unloading, reset the context
+          return;
+        }
+        // 同上：被新一轮同步取代时立即退出配置扫描
+        // Same as above: abort the config scan once superseded by a newer sync
+        if (plugin.syncState.activeSyncContext !== context) {
+          dump(`[SyncContext] Scan (context=${context}) superseded, aborting config scan.`);
           return;
         }
         const pct = overallTotal > 0 ? Math.floor(((baseProcessedCount + configCount) / overallTotal) * 100) : 100;


### PR DESCRIPTION
## 问题

手机端 Obsidian 切后台再回前台会重连，重连成功后（auth → `StartHandle`）会无条件发起新一轮同步。但上一轮的全库扫描循环只在插件卸载时才退出（`operator.ts` 的两个让出点只检查 `isPluginUnloading`），于是两轮扫描并发跑，同一批文件被重复哈希，手机上表现为「切后台回来又开始一次完整哈希计算」。

旧扫描跑完后还会用已作废的 context 发一整轮上行数据，服务端回包在 `websocket_manager.ts` 里被 context 过滤丢弃，纯属白烧 CPU 和流量。

## 修复

在扫描循环（笔记/附件 + 配置）的让出点加一句 context 归属检查：本轮 `context` 已被新会话取代就直接 `return`，让旧扫描立刻退出。

已跑 `tsc -noEmit -skipLibCheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2QYrNjmd1hNqgzWyR4jFZ