### PR TITLE
fix: 提交扫描哈希时只移除已提交条目，避免哈希白算

### DIFF
--- a/src/lib/sync/operator.ts
+++ b/src/lib/sync/operator.ts
@@ -70,6 +70,26 @@ export const clearAllHashes = async (plugin: FastSync) => {
   plugin.configHashManager.clearAll();
 };
 
+type ScannedHashMap = Map<string, { hash: string; mtime: number; size: number }>;
+
+/**
+ * 提交扫描期算出的哈希，并只移除本次已提交的条目。
+ * scannedXxxHashes 是挂在 syncState 上的全局表，整表 clear 会连带清掉另一轮
+ * 并发扫描刚算出、还没落盘的哈希，导致这些文件的哈希白算、下次同步继续重算。
+ *
+ * Commit hashes computed during the scan, removing only the entries just committed.
+ * The scanned maps live on syncState (global), so clearing the whole map would also
+ * discard hashes a concurrent scan just computed but not yet persisted.
+ */
+function commitScannedHashes(scanned: ScannedHashMap, commit: (m: ScannedHashMap) => void): void {
+  if (scanned.size === 0) return;
+  const committed: ScannedHashMap = new Map(scanned);
+  commit(committed);
+  for (const path of committed.keys()) {
+    scanned.delete(path);
+  }
+}
+
 
 
 /**
@@ -454,10 +474,7 @@ async function receiveSyncEndWrapper(data: unknown, plugin: FastSync, type: "not
     plugin.pendingNoteModifies.clear()
     plugin.localStorageManager.clearPending('pendingNoteModifies')
     // 同步结束，提交扫描阶段计算出的哈希 (Commit hashes calculated during scan)
-    if (plugin.scannedNoteHashes.size > 0) {
-      plugin.fileHashManager.bulkSetFromScanned(plugin.scannedNoteHashes);
-      plugin.scannedNoteHashes.clear();
-    }
+    commitScannedHashes(plugin.scannedNoteHashes, (m) => plugin.fileHashManager.bulkSetFromScanned(m));
     // 同步结束，强制落盘本轮防抖累积的哈希写入
     plugin.fileHashManager.flush();
   } else if (type === "file") {
@@ -468,10 +485,7 @@ async function receiveSyncEndWrapper(data: unknown, plugin: FastSync, type: "not
     plugin.pendingUploadHashes.clear()
     plugin.localStorageManager.clearPending('pendingUploadHashes')
     // 同步结束，提交扫描阶段计算出的哈希 (Commit hashes calculated during scan)
-    if (plugin.scannedFileHashes.size > 0) {
-      plugin.fileHashManager.bulkSetFromScanned(plugin.scannedFileHashes);
-      plugin.scannedFileHashes.clear();
-    }
+    commitScannedHashes(plugin.scannedFileHashes, (m) => plugin.fileHashManager.bulkSetFromScanned(m));
     // 同步结束，强制落盘本轮防抖累积的哈希写入
     plugin.fileHashManager.flush();
   } else if (type === "folder") {
@@ -497,10 +511,7 @@ async function receiveSyncEndWrapper(data: unknown, plugin: FastSync, type: "not
     plugin.pendingConfigModifies.clear()
     plugin.localStorageManager.clearPending('pendingConfigModifies')
     // 同步结束，提交扫描阶段计算出的哈希 (Commit hashes calculated during scan)
-    if (plugin.scannedConfigHashes.size > 0) {
-      plugin.configHashManager.bulkSetFromScanned(plugin.scannedConfigHashes);
-      plugin.scannedConfigHashes.clear();
-    }
+    commitScannedHashes(plugin.scannedConfigHashes, (m) => plugin.configHashManager.bulkSetFromScanned(m));
     // 同步结束，强制落盘本轮防抖累积的哈希写入
     plugin.configHashManager.flush();
   }
@@ -892,14 +903,8 @@ export const handleSync = async function (plugin: FastSync, isLoadLastTime: bool
       }
 
       // Persist any newly computed hashes (breaks the Catch-22)
-      if (plugin.scannedNoteHashes.size > 0) {
-        plugin.fileHashManager.bulkSetFromScanned(plugin.scannedNoteHashes);
-        plugin.scannedNoteHashes.clear();
-      }
-      if (plugin.scannedFileHashes.size > 0) {
-        plugin.fileHashManager.bulkSetFromScanned(plugin.scannedFileHashes);
-        plugin.scannedFileHashes.clear();
-      }
+      commitScannedHashes(plugin.scannedNoteHashes, (m) => plugin.fileHashManager.bulkSetFromScanned(m));
+      commitScannedHashes(plugin.scannedFileHashes, (m) => plugin.fileHashManager.bulkSetFromScanned(m));
       dump(`[ScanPerf] Scan done: ${hashComputeCount}/${MAX_HASH_PER_CYCLE} hashes computed, notes=${notes.length}, files=${files.length}, folders=${folders.length}`);
 
       // 检测被删除的文件 (对比哈希表和本地 Vault)

--- a/src/lib/sync/sync_state.ts
+++ b/src/lib/sync/sync_state.ts
@@ -240,9 +240,13 @@ export class SyncState {
     this.configSyncEnd = false;
     this.folderSyncEnd = false;
     this.offlineGuardSkippedThisRound = false;
-    this.scannedNoteHashes.clear();
-    this.scannedFileHashes.clear();
-    this.scannedConfigHashes.clear();
+    // 注意：不再清空 scannedXxxHashes。这些哈希是扫描期实打实算出来的，条目自带 mtime/size 校验，
+    // 留到下一轮同步结束时提交依然有效；在这里清空会把上一轮（可能仍在收尾）算出的哈希白白丢掉，
+    // 导致同一批文件每次同步都要重算。提交由 operator.ts 的 commitScannedHashes 按键移除。
+    // Note: scannedXxxHashes are intentionally NOT cleared here. They are real computed hashes
+    // carrying their own mtime/size for validation, so they stay valid for the next commit.
+    // Clearing them here threw away work from a round that was still finishing, forcing the same
+    // files to be re-hashed on every sync. Entries are removed per-key by commitScannedHashes.
   }
 
   /**


### PR DESCRIPTION
## 问题

`scannedNoteHashes` / `scannedFileHashes` / `scannedConfigHashes` 是挂在 `syncState` 上的**全局表**，不是每轮同步的局部变量。于是两轮同步交叠时会互相清空：

- 新一轮 `handleSync` 开头 `resetSyncTasks()` → `resetSession()` 整表 `clear()`，清掉上一轮刚算出的哈希；
- 旧一轮收尾时 `bulkSetFromScanned(...)` 之后又整表 `clear()`，把新一轮刚算出、还没落盘的哈希一起抹掉。

结果：哈希算了但存不进 `fileHashManager`，下次同步 `getValidHash` 依然 miss，同一批文件反复重算。手机切后台回前台每次都像在做一次完整哈希计算，根因就在这里。

## 修复

- 新增 `commitScannedHashes()`：提交后只按键删除**本次已提交**的条目；
- `resetSession()` 不再清空这三张表（条目自带 mtime/size 校验，留到下一轮提交依然有效）。

`bulkSetFromScanned` 只写本地缓存表、不碰同步基准表，所以保留未提交条目不会影响 baseHash 判定。

已跑 `tsc -noEmit -skipLibCheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2QYrNjmd1hNqgzWyR4jFZ