### PR TITLE
fix: 连接断开时作废当前同步 context

### DIFF
--- a/src/lib/sync/websocket_manager.ts
+++ b/src/lib/sync/websocket_manager.ts
@@ -167,6 +167,12 @@ export class WebSocketManager {
         if (this.plugin.isSyncing) {
           this.plugin.isSyncing = false;
           this.plugin.isSyncRequesting = false;
+          // 连接断开后本轮同步已不可能继续：一并作废其 context，让仍在跑的扫描循环
+          // 在下一个让出点自行退出，否则它会一直扫到底并用作废的 context 发一轮数据
+          // The round can't continue once the socket is gone: invalidate its context so an
+          // in-flight scan bails out at its next yield point instead of scanning to completion
+          // and sending a full round under a dead context.
+          this.plugin.syncState.activeSyncContext = null;
         }
         clearUploadQueue();
         this.plugin.concurrencyLimiter.clear();


### PR DESCRIPTION
## 问题

`websocket_manager.ts` 的 `onClose` 里只把 `isSyncing` 置回 `false`，但 `activeSyncContext` 还留着。这样一来：

- 重入保护没了 —— 重连后能立刻再开一轮同步；
- 在途的全库扫描不知道自己该停，会一路扫到底，再用一个早就断掉的连接发完整一轮数据。

## 修复

断开时一并清空 `activeSyncContext`，配合扫描循环里的 context 归属检查，在途扫描会在下一个让出点自行退出。

已跑 `tsc -noEmit -skipLibCheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2QYrNjmd1hNqgzWyR4jFZ