### PR TITLE
fix: 回前台重连去抖，避免一次切前台触发两轮同步

### DIFF
--- a/src/lib/utils/events_manager.ts
+++ b/src/lib/utils/events_manager.ts
@@ -16,6 +16,7 @@ export class EventManager {
   //保存待处理的重命名文件的路径，用于跳过同时触发的 modify 事件
   private pendingRenamePaths: Set<string> = new Set()
   private blurTimer: number | null = null
+  private resumeTimer: number | null = null
 
   constructor(plugin: FastSync) {
     this.plugin = plugin
@@ -72,6 +73,28 @@ export class EventManager {
       window.clearTimeout(this.blurTimer)
       this.blurTimer = null
     }
+    if (this.resumeTimer) {
+      window.clearTimeout(this.resumeTimer)
+      this.resumeTimer = null
+    }
+  }
+
+  /**
+   * 回到前台后的重连：focus 与 visibilitychange 通常会连着各触发一次，
+   * 这里做 1s 去抖并只在连接确实断开时才重连，避免一次切前台触发两轮同步。
+   * Foreground resume reconnect: focus and visibilitychange usually both fire, so debounce
+   * for 1s and only reconnect when the socket is actually down — one resume, one sync.
+   */
+  private scheduleResumeReconnect(source: string) {
+    if (this.resumeTimer) window.clearTimeout(this.resumeTimer)
+    this.resumeTimer = window.setTimeout(() => {
+      this.resumeTimer = null
+      if (this.plugin.websocket?.isConnected()) {
+        dump(`Resume reconnect skipped (${source}): connection still alive`)
+        return
+      }
+      this.plugin.websocket?.triggerReconnect()
+    }, 1000)
   }
 
   private onOnline = () => {
@@ -97,9 +120,9 @@ export class EventManager {
         dump("Obsidian Mobile Focus (Timer cancelled)")
       }
       dump("Obsidian Mobile Plugin Focus")
-      // 回到前台立即重置退避计数器并重连
-      // Reset backoff counter and reconnect immediately when returning to foreground
-      this.plugin.websocket?.triggerReconnect()
+      // 回到前台重置退避计数器并重连（与 visibilitychange 合并去抖）
+      // Reset backoff counter and reconnect on foreground (debounced with visibilitychange)
+      this.scheduleResumeReconnect("focus")
     }
   }
 
@@ -125,9 +148,9 @@ export class EventManager {
         this.plugin.websocket?.unRegister()
       }
     } else {
-      // 恢复可见时立即重置退避计数器并重连
-      // Reset backoff counter and reconnect immediately when becoming visible again
-      this.plugin.websocket?.triggerReconnect()
+      // 恢复可见时重置退避计数器并重连（与 focus 合并去抖）
+      // Reset backoff counter and reconnect when visible again (debounced with focus)
+      this.scheduleResumeReconnect("visibilitychange")
       // 恢复前台时刷新分享状态（覆盖短暂后台期间其他设备变更分享的场景）
       // Refresh share state on foreground resume (covers share changes by other devices during brief background)
       void this.plugin.shareIndicatorManager?.syncWithServer()


### PR DESCRIPTION
## 问题

手机回到前台时，`onWindowFocus` 和 `onVisibilityChange` 会**各调一次** `triggerReconnect()`。而每次重连成功（auth → `StartHandle`）都会无条件发起一轮同步，也就是一次全库扫描。

## 修复

把两个入口合并到 `scheduleResumeReconnect()`：1s 去抖，且只在 `!isConnected()` 时才真的重连。一次切前台 = 一次重连 = 一轮同步。定时器在 `stop()` 里一并清理。

> 注：重连后「是否该立刻全库扫描」本身还值得再加个节流（比如距上次成功同步不足 N 分钟就跳过扫描、只补发 pending 变更），涉及同步策略取舍，没有放进这个 PR。

已跑 `tsc -noEmit -skipLibCheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2QYrNjmd1hNqgzWyR4jFZ